### PR TITLE
Fix call to non existing function log_overwrites

### DIFF
--- a/SpiffWorkflow/specs/Merge.py
+++ b/SpiffWorkflow/specs/Merge.py
@@ -51,7 +51,7 @@ def _log_overwrites(dst, src):
     for k, v in src.items():
         if k in dst:
             if isinstance(v, dict) and isinstance(dst[k], dict):
-                log_overwrites(v, dst[k])
+                _log_overwrites(v, dst[k])
             else:
                 if v != dst[k]:
                     LOG.warning("Overwriting %s=%s with %s" % (k, dst[k], v))


### PR DESCRIPTION
When I use the Merge spec, I get "NameError: global name 'log_overwrites' is not defined".
The issue is a simple typo in the code. It called `log_overwrites` instead of `_log_overwrites`.
This commit, fixes it.
